### PR TITLE
basic working demo / refactor

### DIFF
--- a/ObjectDetect-copy.py
+++ b/ObjectDetect-copy.py
@@ -5,6 +5,7 @@ import PIL
 import torchvision.models as models
 from torchvision import transforms as T
 import numpy as np
+import datetime
 
 app = Flask(__name__)
 model = 'avert your eyes'
@@ -24,9 +25,10 @@ class DummyNetwork(torch.nn.Module):
     def forward(self, scene_image, target_images):
         # assumes images are already pytorch Tensors
         # run the images through the backbone model
+        print("start backboning")
         scene_features = self.backbone(scene_image)
         target_features = self.backbone(target_images)
-
+        print("end backboning")
         # in the real model we would do more computation for object detection
 
         # now just output something silly for testing purposes
@@ -101,8 +103,11 @@ def object_detector():
 
     scene = np.array(req['scene'])
     targets = [np.array(i) for i in req['targets']]
+    currentDT = datetime.datetime.now()
+    print("hi")
     boxes, scores = model.do_object_detection(scene, targets)
-
+    currentDT = datetime.datetime.now()
+    print("hi2")
     return jsonify({'boxes': boxes, 'scores': scores})
 
 
@@ -111,8 +116,9 @@ def init_state():
 
     # get gpu if available, otherwise use CPU
     # uncomment second line if you want to try to use a gpu
-    device = torch.device("cpu")
-    #device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    #device = torch.device("cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    print(torch.cuda.is_available())
 
     # image transforms for converting from numpy to pytorch format
     scene_transform = T.Compose([

--- a/ObjectDetect-copy.py
+++ b/ObjectDetect-copy.py
@@ -1,142 +1,142 @@
 from flask import Flask, request, Response
 from flask import jsonify
 import torch
+import PIL
 import torchvision.models as models
 from torchvision import transforms as T
 import numpy as np
-import math
-import PIL
+
 app = Flask(__name__)
 model = 'avert your eyes'
+
 
 class DummyNetwork(torch.nn.Module):
     def __init__(self, scene_image_transform=None, target_image_transform=None,
                  device=None):
-        super(DummyNetwork,self).__init__()
+        super(DummyNetwork, self).__init__()
         vgg = models.vgg16_bn(pretrained=False)
-        self.backbone = torch.nn.Sequential(*list(vgg.features.children())[:-1])
+        self.backbone = torch.nn.Sequential(
+            *list(vgg.features.children())[:-1])
         self.scene_image_transform = scene_image_transform
         self.target_image_transform = target_image_transform
         self.device = device
 
-    def forward(self,scene_image,target_images):
-    
-        #assumes images are already pytorch Tensors 
-        #run the images through the backbone model
+    def forward(self, scene_image, target_images):
+        # assumes images are already pytorch Tensors
+        # run the images through the backbone model
         scene_features = self.backbone(scene_image)
         target_features = self.backbone(target_images)
 
-        #in the real model we would do more computation for object detection
+        # in the real model we would do more computation for object detection
 
-        #now just output something silly for testing purposes
-        num_rows = scene_image.shape[0]
-        num_cols = scene_image.shape[1]
-        boxes = [[0,0,num_cols//4, num_rows//4],
-            [num_cols//2,num_rows//2,num_cols-1,num_rows-1]]
-        scores = [.8,.4]
-        return boxes,scores
+        # now just output something silly for testing purposes
+        # these were 0 and 1, but that doesn't seem like it was right.
+        num_rows = scene_image.shape[2]
+        num_cols = scene_image.shape[3]
+        print(scene_image.shape)
 
-    def do_object_detection(self,scene_image,target_images):
+        boxes = [[0, 0, num_cols//4, num_rows//4],
+                 [num_cols//2, num_rows//2, num_cols-1, num_rows-1]]
+        scores = [.8, .4]
+
+        return boxes, scores
+
+    def do_object_detection(self, scene_image, target_images):
         '''
             scene_image: a single Height x Width x Channel (numpy) image
             target_images: a list of H x W x C  (numpy) images
-
             Channel is RGB, so should be 3
-            
         '''
 
         topil = T.ToPILImage()
 
-        #convert the images to the format the object deteciton model needs
+        # convert the images to the format the object deteciton model needs
         if not(self.scene_image_transform is None):
-            #scene_image = T.ToPILImage()(scene_image.astype(np.uint8))
             scene_image = topil(scene_image.astype(np.uint8))
             scene_image = self.scene_image_transform(scene_image)
+
         if not(self.target_image_transform is None):
             transformed_target_images = []
             for target_image in target_images:
-                transformed_target_images.append(self.target_image_transform(target_image.astype(np.float32)))
+                transformed_target_images.append(
+                    self.target_image_transform(target_image.astype(np.float32)))
 
-        #concatenate the target images to a single matrix
-        transformed_target_images = torch.stack(transformed_target_images,dim=0)
-        #add a batch dimension to the scene image
+        # concatenate the target images to a single matrix
+        transformed_target_images = torch.stack(
+            transformed_target_images, dim=0)
+        # add a batch dimension to the scene image
         scene_image = scene_image.unsqueeze(0)
-        #put the images on the gpu if available
+        # put the images on the gpu if available
         scene_image = scene_image.to(self.device).float()
-        transformed_target_images = transformed_target_images.to(self.device).float()
+        transformed_target_images = transformed_target_images.to(
+            self.device).float()
 
-        boxes, scores = self(scene_image,transformed_target_images)
-        return boxes,scores
+        boxes, scores = self(scene_image, transformed_target_images)
+        return boxes, scores
 
-@app.route('/detect', methods=['POST', 'GET'])
+
+@app.route('/detect', methods=['POST'])
 def object_detector():
-    r = request.get_json()
-    #print(r['scene'])
-    print(type(r['scene']))
-    scene_image = np.array(r['scene'], np.float32)
-    true_scene_image = np.ndarray((math.floor((len(scene_image)/4)), 1, 3))
-    for index in range(0, len(scene_image)):
-        if index % 4 == 3:
-            continue
-        true_scene_image[math.floor(index / 4)][0][index % 4] = scene_image[index]
+    req = request.json
 
-    target_images = [np.array(i, np.float32) for i in r['targets']]
-    true_target_images = []
-    for img in target_images:
-        true_target_image = np.ndarray((math.floor((len(img)/4)), 1, 3))
-        for index in range(0, len(img)):
-            if index % 4 == 3:
-                continue
-            true_target_image[math.floor(index / 4)][0][index % 4] = img[index]
-        true_target_images.append(true_target_image)
+    # send a 400 if the scene image isn't provided
+    if 'scene' not in req:
+        app.make_response(
+            (
+                'no scene image provided',
+                400,
+                {'mimetype': 'application/json'}
+            )
+        )
 
-    #make blank images
-    #scene_image = np.zeros((200,200,3))
-    #target images must be the same size (for now)
-    #target_images = []
-    #target_images.append(np.zeros((100,100,3)))
-    #target_images.append(np.zeros((100,100,3)))
+    # send a 400 if the target image(s) aren't provided
+    if 'targets' not in req:
+        app.make_response(
+            (
+                'no target images provided',
+                400,
+                {'mimetype': 'application/json'}
+            )
+        )
 
-    boxes,scores = model.do_object_detection(true_scene_image,true_target_images)
+    scene = np.array(req['scene'])
+    targets = [np.array(i) for i in req['targets']]
+    boxes, scores = model.do_object_detection(scene, targets)
 
-    returned = dict()
-    returned['boxes'] = boxes
-    returned['scores'] = scores
-    print("here1")
-    print(jsonify(returned))
-    return jsonify(returned)
+    return jsonify({'boxes': boxes, 'scores': scores})
+
 
 def init_state():
-    model_parameters_filename = './model_dummy.pth'   
+    model_parameters_filename = './model_dummy.pth'
 
-    #get gpu if available, otherwise use CPU
-    #uncomment second line if you want to try to use a gpu
+    # get gpu if available, otherwise use CPU
+    # uncomment second line if you want to try to use a gpu
     device = torch.device("cpu")
     #device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    
 
-    #image transforms for converting from numpy to pytorch format
+    # image transforms for converting from numpy to pytorch format
     scene_transform = T.Compose([
-                                  T.ToTensor(), 
-                                  T.Normalize([0.485, 0.456, 0.406],
-                                              [0.229, 0.224, 0.225]),
-                                ]) 
+        T.ToTensor(),
+        T.Normalize([0.485, 0.456, 0.406],
+                    [0.229, 0.224, 0.225]),
+    ])
     target_transform = T.Compose([
-                                  T.ToTensor(), 
-                                  T.Normalize([0.485, 0.456, 0.406],
-                                              [0.229, 0.224, 0.225]),
-                                ]) 
- 
-    #init the model object
+        T.ToTensor(),
+        T.Normalize([0.485, 0.456, 0.406],
+                    [0.229, 0.224, 0.225]),
+    ])
+
+    # init the model object
     global model
     model = DummyNetwork(
-                            scene_image_transform=scene_transform,
-                            target_image_transform=target_transform,
-                            device=device, 
-                        )
-    #load the model parameters
+        scene_image_transform=scene_transform,
+        target_image_transform=target_transform,
+        device=device,
+    )
+    # load the model parameters
     model.load_state_dict(torch.load(model_parameters_filename).state_dict())
     model = model.to(device)
+
 
 if __name__ == '__main__':
     init_state()

--- a/src/control/app.jsx
+++ b/src/control/app.jsx
@@ -2,23 +2,24 @@ export default class App {
     constructor() {
         this.images = [];
         this.image_key = 0;
+        this.scene_image = '';
     }
 
     addImage(img_path) {
-        console.log('adding an image');
         this.images.push(img_path);
-        console.log(this.images);
         return this.image_key++;
     }
 
     removeAllImages() {
-        console.log('removing all images');
         this.images = [];
         this.image_key = 0;
     }
 
     getImages() {
-        console.log('getting images');
         return this.images;
+    }
+
+    setSceneImage(img_path) {
+        this.scene_image = img_path;
     }
 }

--- a/src/control/imageops.jsx
+++ b/src/control/imageops.jsx
@@ -1,0 +1,54 @@
+/**
+ * Given a string referencing the location of an image on the local filesystem,
+ * draw the image to a canvas and then extract an ImageData object from the
+ * canvas' context.
+ * @param {String} url 
+ */
+function getImageDataFromURL(url) {
+    let img = new Image();
+    let canvas = document.createElement('canvas');
+    let context = canvas.getContext('2d');
+
+    img.src = url;
+
+    // the width and height of the canvas need to be scaled to reflect the dimensions
+    // of the image which is being drawn. 
+    canvas.width = img.naturalWidth;
+    canvas.height = img.naturalHeight;
+
+    // console.log(`${canvas.width}, ${canvas.height}`);
+
+    context.drawImage(img, 0, 0);
+
+    return context.getImageData(0, 0, canvas.width, canvas.height);
+}
+
+/**
+ * Convert the ImageData associated with an image into a format which can
+ * easily be dealt with by numpy when sent to the Flask sever.
+ * @param {ImageData} image_data
+ */
+function produceRGBArray(image_data) {
+    let image_width = image_data.width;
+    let image_height = image_data.height;
+    let result = [];
+    let idx = 0;
+
+    for (let x = 0; x < image_width; x++) {
+        let column = [];
+
+        for (let y = 0; y < image_height; y++) {
+            let red = image_data.data[idx++];
+            let green = image_data.data[idx++];
+            let blue = image_data.data[idx++];
+            idx++; // dump the alpha component
+            column.push([red, green, blue]);
+        }
+
+        result.push(column);
+    }
+
+    return result;
+}
+
+export { getImageDataFromURL, produceRGBArray };

--- a/src/entrypoint.jsx
+++ b/src/entrypoint.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ImageChoiceScreen from './image_choice_screen/image_choice_screen';
-import App from './control/app';
 import SceneSelectionScreen from './scene_selection_screen/scene_selection_screen';
 import OutputScreen from './output_screen/output_screen';
-import { displayErrorDialog } from './control/dialogs';
+import App from './control/app';
 
 window.onload = () => {
     initialize();
@@ -29,46 +28,6 @@ function displaySceneSelectionScreen(app) {
 }
 
 function displayOutputScreen(app) {
-    var xhttp = new XMLHttpRequest();
-    xhttp.open("POST", "http://127.0.0.1:5000/detect", false);
-
-    let imgPaths = app.images;
-    let imgs = [];
-
-    function getPixels(url) {
-        var img = new Image();
-        img.src = url;
-        var canvas = document.createElement('canvas');
-        var context = canvas.getContext('2d');
-        context.drawImage(img, 0, 0);
-        return context.getImageData(0, 0, canvas.width, canvas.height).data;
-    }
-    
-    let getArrayFromClampedArray = function(clampedArray) {
-        let x = [];
-        clampedArray.forEach((y) => x[x.length] = y);
-        return x;
-    }
-
-    imgPaths.forEach(function (imgPath) {
-        imgs[imgs.length] = getArrayFromClampedArray(getPixels(imgPath))
-	    console.log(getPixels(imgPath))
-    })
-
-    xhttp.onreadystatechange = function () {
-        var response = JSON.parse(xhttp.responseText);
-        console.log(response);
-    }
-    xhttp.setRequestHeader("Content-Type", "application/json");
-    // TODO: what do we want to do here? stay on the current screen? 
-    // TODO: go to the next one and render nothing?
-    try {
-	var obj = {scene: imgs[0], targets: [imgs[1]]}
-        xhttp.send(JSON.stringify(obj))
-    } catch (err) {
-        displayErrorDialog('failed to connect to server');
-    }
-
     ReactDOM.render(
         <OutputScreen app={app} />,
         document.getElementById('root')

--- a/src/image_choice_screen/image_choice_screen.jsx
+++ b/src/image_choice_screen/image_choice_screen.jsx
@@ -30,17 +30,17 @@ class ImageContainer extends React.Component {
     }
 
     uploadImage() {
-        let file_upload = displayImageUploadDialog();
+        const file_upload = displayImageUploadDialog();
         if (file_upload === undefined) return;
 
-        let key = this.props.app.addImage(file_upload); // notify the app that we've added a new image - it will give us a key
-        let imgs = this.state.images;
-        imgs.push(<Image key={key} src={file_upload} />);
+        const key = this.props.app.addImage(file_upload[0]); // notify the app that we've added a new image - it will give us a key
+        const imgs = this.state.images;
+        imgs.push(<Image key={key} src={file_upload[0]} />);
         this.setState({ images: imgs });
     }
 
     clearAllImages() {
-        let user_choice = displayYesNoDialog('Are you sure you want to remove all images?');
+        const user_choice = displayYesNoDialog('Are you sure you want to remove all images?');
 
         if (user_choice === 0) {
             this.props.app.removeAllImages(); // dump all images from the app

--- a/src/output_screen/output_screen.jsx
+++ b/src/output_screen/output_screen.jsx
@@ -1,11 +1,12 @@
 import { displayImageChoiceScreen, displaySceneSelectionScreen } from '../entrypoint';
+import { getImageDataFromURL, produceRGBArray } from '../control/imageops';
 import React from 'react';
 
 export default class OutputScreen extends React.Component {
     render() {
         return (
             <div>
-                <OutputScreenContainer />
+                <OutputScreenContainer app={this.props.app}/>
                 <div className='button' onClick={() => displayImageChoiceScreen(this.props.app)}>Image choice</div>
                 <div className='button' onClick={() => displaySceneSelectionScreen(this.props.app)}>Scene selection</div>
             </div>
@@ -14,11 +15,70 @@ export default class OutputScreen extends React.Component {
 }
 
 class OutputScreenContainer extends React.Component {
+    constructor(props) {
+        super(props);
+        this.canvas_ref = React.createRef();
+    }
+
+    /**
+     * The changes made here are based on this link: 
+     */
+    componentDidMount() {
+        let xhttp = new XMLHttpRequest();
+        let target_images = [];
+        let response;
+    
+        // convert image paths to arrays of image data
+        this.props.app.images.forEach(img_path => target_images.push(produceRGBArray(getImageDataFromURL(img_path))));
+    
+        // setup the XHR
+        xhttp.open('POST', 'http://127.0.0.1:5000/detect', false);
+        xhttp.setRequestHeader('Content-Type', 'application/json');
+        xhttp.onreadystatechange = () => {
+            if (xhttp.readyState === XMLHttpRequest.DONE && xhttp.status === 200) {
+                response = JSON.parse(xhttp.responseText);
+            } else if (xhttp.status === 400) {
+                displayErrorDialog('server responded with 400.');
+            } else {
+                displayErrorDialog(`status: ${xhttp.status}, text: ${xhttp.responseText}`);
+            }
+        };
+    
+        try {
+            let scene = produceRGBArray(getImageDataFromURL(this.props.app.scene_image));
+            xhttp.send(JSON.stringify({ scene: scene, targets: target_images }));
+        } catch (err) {
+            console.log(err);
+            //displayErrorDialog('failed to connect to server');
+            return; // TODO: for now we can just return prematurely
+        }
+
+        const canvas = this.canvas_ref.current;
+        const ctx = canvas.getContext('2d');
+        const scene_image = new Image();
+        
+        scene_image.src = this.props.app.scene_image;
+
+        canvas.width = scene_image.naturalWidth;
+        canvas.height = scene_image.naturalHeight;
+
+        ctx.drawImage(scene_image, 0, 0);
+
+        ctx.strokeStyle = 'red';
+        console.log(response);
+        const num_boxes = response['boxes'].length;
+
+        for (let i = 0; i < num_boxes; i++) {
+            const [top_x, top_y, bot_x, bot_y] = response['boxes'][i];
+            const confidence = response['scores'][i];
+            const height = bot_y - top_y;
+
+            ctx.strokeRect(top_x, top_y, bot_x, bot_y);
+            ctx.strokeText(`${confidence}`, top_x + 5, top_y + height / 2);
+        }
+    }
+
     render() {
-        return (
-            <div>
-                Here is where a canvas will render frames.
-            </div>
-        );
+        return <canvas ref={this.canvas_ref} />;
     }
 }

--- a/src/scene_selection_screen/scene_selection_screen.jsx
+++ b/src/scene_selection_screen/scene_selection_screen.jsx
@@ -11,7 +11,7 @@ export default class SceneSelectionScreen extends React.Component {
     }
 
     outputScreenClick() {
-        console.log('are you a dumbass?? sure');
+       //jay said to delete this line
 
         // make sure that there is at least one target image before continuing
         if (this.props.app.images.length == 0) {
@@ -54,7 +54,7 @@ class SceneImage extends React.Component {
 
     render() {
         return(
-            <img src={this.state.imageUrl}></img>
+            <img className="sceneImage" src={this.props.url}></img>
         )
     }
 }

--- a/src/scene_selection_screen/scene_selection_screen.jsx
+++ b/src/scene_selection_screen/scene_selection_screen.jsx
@@ -3,8 +3,15 @@ import { displayYesNoDialog, displayImageUploadDialog, displayErrorDialog } from
 import React from 'react';
 
 export default class SceneSelectionScreen extends React.Component {
+    constructor(props){
+        super(props)
+        this.state = {
+            image: null
+        }
+    }
+
     outputScreenClick() {
-        console.log('are you a dumbass??');
+        console.log('are you a dumbass?? sure');
 
         // make sure that there is at least one target image before continuing
         if (this.props.app.images.length == 0) {
@@ -26,15 +33,37 @@ export default class SceneSelectionScreen extends React.Component {
         return (
             <div>
                 <SceneSelectionScreenTitle />
-                <SceneSelectionContainer app={this.props.app}/>
+                <SceneSelectionContainer parent={this} app={this.props.app}/>
                 <div className='button' onClick={() => displayImageChoiceScreen(this.props.app)}>Image choice</div>
                 <div className='button' onClick={() => this.outputScreenClick()}>Output</div>
+                <div className="sceneImageDiv">
+                    {this.state.image}
+                </div>
             </div>
         );
     }
 }
 
+class SceneImage extends React.Component {
+    constructor(props){
+        super(props)
+        this.state = {
+            imageUrl: props.url
+        }
+    }
+
+    render() {
+        return(
+            <img src={this.state.imageUrl}></img>
+        )
+    }
+}
+
 class SceneSelectionContainer extends React.Component {
+    constructor(props) {
+        super(props)
+        this.parent = props.parent
+    }
     handleSceneImageUpload() {
         let img_paths = displayImageUploadDialog();
         if (img_paths === undefined) return;
@@ -42,6 +71,8 @@ class SceneSelectionContainer extends React.Component {
         let scene_img_path = img_paths[0];
         console.log(`set the scene image: ${scene_img_path}`);
         this.props.app.setSceneImage(scene_img_path);
+        this.parent.setState({image: <SceneImage url={scene_img_path}></SceneImage>})
+        
     }
 
     handleWebcam() {

--- a/src/scene_selection_screen/scene_selection_screen.jsx
+++ b/src/scene_selection_screen/scene_selection_screen.jsx
@@ -1,33 +1,65 @@
 import { displayImageChoiceScreen, displayOutputScreen } from '../entrypoint';
-import { displayYesNoDialog, displayImageUploadDialog } from '../control/dialogs';
+import { displayYesNoDialog, displayImageUploadDialog, displayErrorDialog } from '../control/dialogs';
 import React from 'react';
 
 export default class SceneSelectionScreen extends React.Component {
+    outputScreenClick() {
+        console.log('are you a dumbass??');
+
+        // make sure that there is at least one target image before continuing
+        if (this.props.app.images.length == 0) {
+            displayErrorDialog('you must provide at least one target image');
+            return;
+        }
+
+        // this is temporary -- check to see if the user has provided a scene image
+        if (this.props.app.scene_image == '') {
+            displayErrorDialog('you must provide a scene image');
+            return;
+        }
+
+        displayOutputScreen(this.props.app);
+
+    }
+
     render() {
         return (
             <div>
                 <SceneSelectionScreenTitle />
-                <SceneSelectionContainer />
+                <SceneSelectionContainer app={this.props.app}/>
                 <div className='button' onClick={() => displayImageChoiceScreen(this.props.app)}>Image choice</div>
-                <div className='button' onClick={() => displayOutputScreen(this.props.app)}>Output</div>
+                <div className='button' onClick={() => this.outputScreenClick()}>Output</div>
             </div>
         );
     }
 }
 
 class SceneSelectionContainer extends React.Component {
+    handleSceneImageUpload() {
+        let img_paths = displayImageUploadDialog();
+        if (img_paths === undefined) return;
+
+        let scene_img_path = img_paths[0];
+        console.log(`set the scene image: ${scene_img_path}`);
+        this.props.app.setSceneImage(scene_img_path);
+    }
+
+    handleWebcam() {
+        displayYesNoDialog('we still need to get webcam interop working.')
+    }
+
     render() {
         return (
             <div>
                 <div
                     className='button'
-                    onClick={() => displayImageUploadDialog()}
+                    onClick={() => this.handleSceneImageUpload()}
                 >
-                    Upload a scene
+                    Upload scene image
                 </div>
                 <div
                     className='button'
-                    onClick={() => displayYesNoDialog('we still need to get webcam interop working.')}
+                    onClick={() => this.handleWebcam()}
                 >
                     Use your webcam
                 </div>

--- a/themes/mainCSS.css
+++ b/themes/mainCSS.css
@@ -53,3 +53,8 @@ div.imageContainer {
 .button:hover {
 	box-shadow: 0px 0px 0px white;
 }
+
+.sceneImage {
+	height: 300px;
+	width: 300px;
+}


### PR DESCRIPTION
- added 400 responses from the server if the client forgets to add the target images or the scene
- the work of converting to a format appropriate for np got moved to the client side in the imageops file
- the XHR to the server for bounding boxes was moved within the output_screen
- a bit of state called 'scene' was added to the app object to track the image a user uploaded as a scene. this will have to be changed somewhat when webcam support is added, i suppose.